### PR TITLE
[style] detect Markdown files and force LF on line endings for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.md linguist-detectable=true
+README.md linguist-detectable=false
+
+* text=auto eol=lf


### PR DESCRIPTION
The posts are written in Markdown and it happens to be the only language used in this repo, Github by default considers markdown files as documentation source and does not display it in the repo's used languages. Since wiki-posts is used only for writing docs, guides, tutorials etc... it makes sense to allow Markdown to be detected as language used by this repository and I personally think it looks fancy. Github uses [linguist](https://github.com/github/linguist) to generate code languages report and its settings can be overridden in `.gitattributes` file as explained [here](https://github.com/github/linguist/blob/master/docs/overrides.md).

The second change forces text files to be committed with `LF` line endings (the file will keep the same line ending on the committer host system) this is just for consistency to avoid unwanted changes caused by text editor that uses `CRLF` for line endings.